### PR TITLE
EARTH-141: Removes the secondary sidebar nav component and dependency.

### DIFF
--- a/stanford_page.info.yml
+++ b/stanford_page.info.yml
@@ -18,8 +18,6 @@ dependencies:
   - rdf
   - responsive_image
   - scheduler
-  - stanford_components
   - system (>= 8.3.x)
   - text
-  - ui_patterns
   - user

--- a/stanford_page.module
+++ b/stanford_page.module
@@ -32,13 +32,6 @@ function stanford_page_theme($existing, $type, $thing, $path) {
     'base hook' => 'field',
   ];
 
-  // Tell Drupal about the menu
-  $theme['menu__secondary__sidebar__menu'] = [
-    'theme path' => drupal_get_path('module', 'stanford_page'),
-    'path' => drupal_get_path('module', 'stanford_page') . "/templates",
-    'base hook' => 'menu',
-  ];
-
   return $theme;
 }
 

--- a/templates/menu--secondary--sidebar--menu.html.twig
+++ b/templates/menu--secondary--sidebar--menu.html.twig
@@ -1,1 +1,0 @@
-{{ pattern('secondary_sidebar_nav', {items: items}) }}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Drops the dependency on "no-longer-exists" component
- Drops the dependency on stanford_components and ui_patterns module.

# Needed By (Date)
- Soonish would be good. Things are breaking right now.

# Urgency
- Moderately critical.

# Steps to Test

1. Review the pr 
2. Check out the code
3. Clear caches and view a basic page that has a sidebar nav
4. If page loads it works otherwise you will see a slew of error messages

# Affected Projects or Products
- Earth and everything after EARTH-141 gets merged.


# Associated Issues and/or People
- @slowbot 
- @koppieesq 
- EARTH-141 and subsequent PRs.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)