### PR TITLE
EARTH-1418-revision-error Check for node object in Stanford Page prep…

### DIFF
--- a/stanford_page.module
+++ b/stanford_page.module
@@ -17,7 +17,8 @@ function stanford_page_preprocess_page(&$vars) {
   $node = \Drupal::routeMatch()->getParameter('node');
 
   // Not a node.. Then just continue.
-  if (!$node) {
+  if (empty($node) || !is_object($node) ||
+    get_class($node) !== 'Drupal\node\Entity\Node') {
     return;
   }
 


### PR DESCRIPTION
# READY

# Summary
- Attempting to revert a Stanford News node on Earth results in a 502 error. 
- Fix adds node object check to stanford_page.module preprocess_page hook.

# Needed By (Date)
- ASAP

# Urgency
- Bug fix.

# Steps to Test

1. Note: Stanford Earth currently uses 8.x-1.x of this module. This fix is for version 8.x-2.x
2. If testing against a Stanford Earth build, change stanford_page version in main project composer.json from 8.x-1.x to 8.x-2.x and run "composer update --prefer-source"
3. Pull down this branch in docroot/modules/custom/stanford_page
4. Try to revert a news article such as node/6461

# Affected Projects or Products
- Any site using stanford_page

# Associated Issues and/or People

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)